### PR TITLE
Aws cdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 /target
 .env
 *.zip
+
+.DS_Store
+lambda.zip
+cdk.out
+
+node_modules
+benchmark/trace-summaries.json
+benchmark/traces.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+*.ts
+!*.d.ts
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+# Deployment
+
+Currently, the deploy process is manual, but does leverage infrastructure-as-code
+
+```bash
+# build the binary
+cargo build --release --target x86_64-unknown-linux-musl
+
+# zip it up, so that aws-cdk TS code can point to it
+zip -j rust.zip ./target/x86_64-unknown-linux-musl/release/bootstrap
+
+# deploy with aws-cdk
+cdk deploy
+```
+
 # Errors
 
 ## TS error

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Errors
+
+## TS error
+
+```
+❯ cdk synth
+TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /Users/kevin/repos/rust_weather_cron/index.ts
+    at Loader.defaultGetFormat [as _getFormat] (internal/modules/esm/get_format.js:65:15)
+    at Loader.getFormat (internal/modules/esm/loader.js:116:42)
+    at Loader.getModuleJob (internal/modules/esm/loader.js:247:31)
+    at Loader.import (internal/modules/esm/loader.js:181:17)
+    at Object.loadESM (internal/process/esm_loader.js:84:5)
+```
+
+### Fix:
+
+> [Remove `"type": "module"` from package.json](https://github.com/TypeStrong/ts-node/issues/1062#issuecomment-650746948)

--- a/cdk.json
+++ b/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "npx ts-node --prefer-ts-exts index"
+}

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,60 @@
+import * as events from "@aws-cdk/aws-events";
+import * as targets from "@aws-cdk/aws-events-targets";
+import * as lambda from "@aws-cdk/aws-lambda";
+import * as iam from "@aws-cdk/aws-iam";
+import * as cdk from "@aws-cdk/core";
+import * as dotenv from "dotenv";
+
+/**
+ * Enable CDK to pick up environment variables in `.env`
+ * This will be added to the LambdaFn's env, and read by
+ * the rust binary.
+ */
+dotenv.config();
+
+export class LambdaCronStack extends cdk.Stack {
+  constructor(app: cdk.App, id: string) {
+    super(app, id);
+
+    const customRole = new iam.Role(this, `${id}-customRole`, {
+      roleName: `${id}-customRole`,
+      assumedBy: new iam.ServicePrincipal("lambda.amazonaws.com"),
+      managedPolicies: [
+        // aws-managed
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+          "service-role/AWSLambdaBasicExecutionRole"
+        ),
+        // customer-managed
+        iam.ManagedPolicy.fromManagedPolicyName(
+          this,
+          "DynamoReadAndWrite",
+          "DynamoReadAndWrite"
+        ),
+      ],
+    });
+    const lambdaFn = new lambda.Function(this, "Singleton", {
+      code: lambda.Code.fromAsset("rust.zip", {}),
+      handler: "hello.handler",
+      timeout: cdk.Duration.seconds(10),
+      runtime: lambda.Runtime.PROVIDED_AL2,
+      environment: {
+        API_KEY: process.env.API_KEY!,
+      },
+      role: customRole,
+    });
+
+    /**
+     * Our cron rule — _"Every hour"_
+     * - See https://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html
+     */
+    const rule = new events.Rule(this, "Rule", {
+      schedule: events.Schedule.expression("cron(0 * ? * SUN-SAT *)"),
+    });
+
+    rule.addTarget(new targets.LambdaFunction(lambdaFn));
+  }
+}
+
+const app = new cdk.App();
+new LambdaCronStack(app, "LambdaCronExample");
+app.synth();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,892 @@
+{
+  "name": "rust_weather_cron",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@aws-cdk/assets": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.79.0.tgz",
+      "integrity": "sha512-h4FVseJK2lZ+FB8reFm0V37x0HEyg4mD8DGTb0akIz2A3U0ltmML+PN8EPANxLpSDOPYg2OLNAgPw5MOqXNC5A==",
+      "requires": {
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/cx-api": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-apigateway": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigateway/-/aws-apigateway-1.79.0.tgz",
+      "integrity": "sha512-P66Jnu3kFnEuN5gXm5BDOK/L7sYWu75kWJztTfyW1nOSqGfiGj4cvrXMMvSGrEw2lmEKLnNgAl93M64DbTdT9Q==",
+      "requires": {
+        "@aws-cdk/assets": "1.79.0",
+        "@aws-cdk/aws-certificatemanager": "1.79.0",
+        "@aws-cdk/aws-cloudwatch": "1.79.0",
+        "@aws-cdk/aws-ec2": "1.79.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-lambda": "1.79.0",
+        "@aws-cdk/aws-logs": "1.79.0",
+        "@aws-cdk/aws-s3": "1.79.0",
+        "@aws-cdk/aws-s3-assets": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/cx-api": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-apigatewayv2": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2/-/aws-apigatewayv2-1.79.0.tgz",
+      "integrity": "sha512-+ktXFADC8fQ6Wnt7taTOBu+C5D0FClZ0oBWkIm+IUduLS0UQn2/4Qk1TWvrH64FMqPYSZ2b4dDQR4clv+on6wA==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.79.0",
+        "@aws-cdk/aws-cloudwatch": "1.79.0",
+        "@aws-cdk/aws-ec2": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-applicationautoscaling": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.79.0.tgz",
+      "integrity": "sha512-ctgfkgKorVui7xF01U9djVCnhMrtvnSl0B7LUAnI6gy6uFrzpg9rfaW845c8O+6211OP2v9zrBl06GGPeACkCQ==",
+      "requires": {
+        "@aws-cdk/aws-autoscaling-common": "1.79.0",
+        "@aws-cdk/aws-cloudwatch": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-autoscaling": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.79.0.tgz",
+      "integrity": "sha512-4cvtJZYIoEdXTD+8bhY/MGQSatEz1T3A7L0VEfAhV1Zr9doNyOsKq5ec9f7idfKgyLMxpANP1YSb4qE7lDzsCQ==",
+      "requires": {
+        "@aws-cdk/aws-autoscaling-common": "1.79.0",
+        "@aws-cdk/aws-cloudwatch": "1.79.0",
+        "@aws-cdk/aws-ec2": "1.79.0",
+        "@aws-cdk/aws-elasticloadbalancing": "1.79.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-sns": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-autoscaling-common": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.79.0.tgz",
+      "integrity": "sha512-ZgprhHWRVvBz8Vh0sXYGdRiUm7cga4IzwHftuVu4MUWYu3IlQSm92tj9wv7dfttIT8v4z5idXsDzu3Og91lcjA==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-autoscaling-hooktargets": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.79.0.tgz",
+      "integrity": "sha512-NAo7FB/+6L/Sw5dwwNcI7McUYZbEE6HqjRqEMfDgeW1SrVdZ68q8C9s/Ipn5FLPvQYkKbMHrlc9W+PqzvdcZRQ==",
+      "requires": {
+        "@aws-cdk/aws-autoscaling": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-kms": "1.79.0",
+        "@aws-cdk/aws-lambda": "1.79.0",
+        "@aws-cdk/aws-sns": "1.79.0",
+        "@aws-cdk/aws-sns-subscriptions": "1.79.0",
+        "@aws-cdk/aws-sqs": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-batch": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-batch/-/aws-batch-1.79.0.tgz",
+      "integrity": "sha512-O+onGGmUN2nDyHu96sL6i5vKYxom/yWDxWBKuR+2jmQ105cWvteZuMCK9lGM9dMJQ+nVDaK1ttzlH2IHr1muuw==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.79.0",
+        "@aws-cdk/aws-ecr": "1.79.0",
+        "@aws-cdk/aws-ecs": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-secretsmanager": "1.79.0",
+        "@aws-cdk/aws-ssm": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-certificatemanager": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.79.0.tgz",
+      "integrity": "sha512-8uBXTQXunDZlO2hvMZTnPr3tLM8ayPu/VuMX/Uh1deRf/UmlHyplT/ePwKoyRpeZcHfrGcTTVoQgli2saQxCtg==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-lambda": "1.79.0",
+        "@aws-cdk/aws-route53": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-cloudformation": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.79.0.tgz",
+      "integrity": "sha512-Rayo5xGbfE1gtsgXDcxun1vJJRDbA7VPJtfuMdh0cikpTeTA0/iMfpmg96Rgg+Ry/cxkHV8AFQAU0Va6uHiR2w==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-lambda": "1.79.0",
+        "@aws-cdk/aws-s3": "1.79.0",
+        "@aws-cdk/aws-sns": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/cx-api": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-cloudfront": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.79.0.tgz",
+      "integrity": "sha512-MVbVVBeA8NRlmJ74EVOHM7lnNRmlU6oPz3SlKwS0uY46Zhw26L+5KUupF4UQznMBslMaycE0DyfwgNS9R0su4A==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.79.0",
+        "@aws-cdk/aws-cloudwatch": "1.79.0",
+        "@aws-cdk/aws-ec2": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-kms": "1.79.0",
+        "@aws-cdk/aws-lambda": "1.79.0",
+        "@aws-cdk/aws-s3": "1.79.0",
+        "@aws-cdk/aws-ssm": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-cloudwatch": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.79.0.tgz",
+      "integrity": "sha512-lbcrfUwI/9rvFCMyRa7g8DskqAXThDVrRM4SAdHAX/MCV5cBcb3GA1HzFfnILsq5RXPwoC4WT7hhxMibM4A0iA==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-codebuild": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codebuild/-/aws-codebuild-1.79.0.tgz",
+      "integrity": "sha512-dvcznkli6z93597+Z8ONp8ZbZZu/OMUVf2UGbxVR1SRdo2mpSXOl4nUyxxptLM9oAWQ1C7kEGZQi1SFI6VZgCg==",
+      "requires": {
+        "@aws-cdk/assets": "1.79.0",
+        "@aws-cdk/aws-cloudwatch": "1.79.0",
+        "@aws-cdk/aws-codecommit": "1.79.0",
+        "@aws-cdk/aws-ec2": "1.79.0",
+        "@aws-cdk/aws-ecr": "1.79.0",
+        "@aws-cdk/aws-ecr-assets": "1.79.0",
+        "@aws-cdk/aws-events": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-kms": "1.79.0",
+        "@aws-cdk/aws-logs": "1.79.0",
+        "@aws-cdk/aws-s3": "1.79.0",
+        "@aws-cdk/aws-s3-assets": "1.79.0",
+        "@aws-cdk/aws-secretsmanager": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/region-info": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-codecommit": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codecommit/-/aws-codecommit-1.79.0.tgz",
+      "integrity": "sha512-/AVhiRz6Y5h+H4DD71L4Lha0f2ER+xOOy71RGAlYIc3HAAhs726Fo9qmxp6NHUq8HjlHJ98sh4CVataE7bb8ag==",
+      "requires": {
+        "@aws-cdk/aws-events": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-codeguruprofiler": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.79.0.tgz",
+      "integrity": "sha512-DF7MCJOCSGy9RV6X1ebhHOIggXOsJ21pQUs0mAClTt3/DPNEr0EQuiN30VhaiPxgUnbN3FTppLSLUzjIJSWbQA==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-codepipeline": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.79.0.tgz",
+      "integrity": "sha512-C/4MpcLvnU+dnJ9rjXRlp0bvFaAHLO7Nus6w9TLAfg/rFVSSxjtv5n9METwKWzco9FGB7kYBvAjSFOVbmA6nAA==",
+      "requires": {
+        "@aws-cdk/aws-events": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-kms": "1.79.0",
+        "@aws-cdk/aws-s3": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-cognito": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.79.0.tgz",
+      "integrity": "sha512-m/Xu9VFXetB5DEtxM5irN0NsZK0p1RNh7WgIIoRoym1nQ8pwPvBegQTMaRVgNBnINSyyUtV/GtpArayey5V5Sg==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-lambda": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/custom-resources": "1.79.0",
+        "constructs": "^3.2.0",
+        "punycode": "^2.1.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "bundled": true
+        }
+      }
+    },
+    "@aws-cdk/aws-ec2": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.79.0.tgz",
+      "integrity": "sha512-A2pbynk5o18gKeCy/epMiaD9R4OKrXlWzaqAOvUlHOom+SkxIyZMcALdxgU26nCty0DxGfgQiNHWTgNttLuRJQ==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-kms": "1.79.0",
+        "@aws-cdk/aws-logs": "1.79.0",
+        "@aws-cdk/aws-s3": "1.79.0",
+        "@aws-cdk/aws-s3-assets": "1.79.0",
+        "@aws-cdk/aws-ssm": "1.79.0",
+        "@aws-cdk/cloud-assembly-schema": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/cx-api": "1.79.0",
+        "@aws-cdk/region-info": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-ecr": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.79.0.tgz",
+      "integrity": "sha512-ZidVw6sdwNvMp+y75aH5k4IFMiIDCgpJ11d7tkSk1WKwoVu/pU/ZYLih/clTvFwzqzmh2A63rIyeC4+t5ziAvQ==",
+      "requires": {
+        "@aws-cdk/aws-events": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-ecr-assets": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.79.0.tgz",
+      "integrity": "sha512-pM6X3Q+Uybq9RlX5DSAKfLygyZqYA9eNFvQKmTtuiwt9A+SDAonHrv6xT9EvFQaPHpFnxESpBiuspJTr9hZggQ==",
+      "requires": {
+        "@aws-cdk/assets": "1.79.0",
+        "@aws-cdk/aws-ecr": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-s3": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/cx-api": "1.79.0",
+        "constructs": "^3.2.0",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "@aws-cdk/aws-ecs": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecs/-/aws-ecs-1.79.0.tgz",
+      "integrity": "sha512-VmUQmOpzdg9UobCkaOUioaHcegn6ju8T++Epagirt2IAJBe9sBcj06mUoWfjlBBIXMcG5SMTk30Opx66ppjrfw==",
+      "requires": {
+        "@aws-cdk/aws-applicationautoscaling": "1.79.0",
+        "@aws-cdk/aws-autoscaling": "1.79.0",
+        "@aws-cdk/aws-autoscaling-hooktargets": "1.79.0",
+        "@aws-cdk/aws-certificatemanager": "1.79.0",
+        "@aws-cdk/aws-cloudwatch": "1.79.0",
+        "@aws-cdk/aws-ec2": "1.79.0",
+        "@aws-cdk/aws-ecr": "1.79.0",
+        "@aws-cdk/aws-ecr-assets": "1.79.0",
+        "@aws-cdk/aws-elasticloadbalancing": "1.79.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-kms": "1.79.0",
+        "@aws-cdk/aws-lambda": "1.79.0",
+        "@aws-cdk/aws-logs": "1.79.0",
+        "@aws-cdk/aws-route53": "1.79.0",
+        "@aws-cdk/aws-route53-targets": "1.79.0",
+        "@aws-cdk/aws-s3": "1.79.0",
+        "@aws-cdk/aws-s3-assets": "1.79.0",
+        "@aws-cdk/aws-secretsmanager": "1.79.0",
+        "@aws-cdk/aws-servicediscovery": "1.79.0",
+        "@aws-cdk/aws-sns": "1.79.0",
+        "@aws-cdk/aws-sqs": "1.79.0",
+        "@aws-cdk/aws-ssm": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/cx-api": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-efs": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.79.0.tgz",
+      "integrity": "sha512-iWjyRFKMIvf1tcwFhwcHaLhmLFeC+iknE36t1UvRFxcBV4K8mrHxkXCsJzqZTHpaAFP/LU0pFX04o03508NRWQ==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.79.0",
+        "@aws-cdk/aws-kms": "1.79.0",
+        "@aws-cdk/cloud-assembly-schema": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/cx-api": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-elasticloadbalancing": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.79.0.tgz",
+      "integrity": "sha512-Z8PmDCYs5zkl3WNK9OQvwiZvpyQdfxUeIWRoAGaLJI/g9a0Y/qQX6fRBHByTj2nwpKherg7XGlY+hJXmRrJBWQ==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-elasticloadbalancingv2": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.79.0.tgz",
+      "integrity": "sha512-kCEt2uKd8cyX7dvrbXOTqDFB8Isf75HI2Bj4I/GX6asnb9kK7DUEfvSDCFshEw6OJMAWEhL4TNPhIYJ94G3Eww==",
+      "requires": {
+        "@aws-cdk/aws-certificatemanager": "1.79.0",
+        "@aws-cdk/aws-cloudwatch": "1.79.0",
+        "@aws-cdk/aws-ec2": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-lambda": "1.79.0",
+        "@aws-cdk/aws-s3": "1.79.0",
+        "@aws-cdk/cloud-assembly-schema": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/cx-api": "1.79.0",
+        "@aws-cdk/region-info": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-events": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.79.0.tgz",
+      "integrity": "sha512-9fyvKqSC/Sa5cVe2SyvTrTBNw8MuZ8w29JX6O9McMff1i50ZMpdSFh/r/Hq4ImfcoRJvZcyXDYJmTUI8PYR6Fg==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-events-targets": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events-targets/-/aws-events-targets-1.79.0.tgz",
+      "integrity": "sha512-nkFxA4NuVN1myENlCy2CZRY513BujA1v5Ui94tLewfAzcBHEzOPXdZckXiArZJp0MAamTXw++esr8g8td9xoQQ==",
+      "requires": {
+        "@aws-cdk/aws-batch": "1.79.0",
+        "@aws-cdk/aws-codebuild": "1.79.0",
+        "@aws-cdk/aws-codepipeline": "1.79.0",
+        "@aws-cdk/aws-ec2": "1.79.0",
+        "@aws-cdk/aws-ecs": "1.79.0",
+        "@aws-cdk/aws-events": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-kinesis": "1.79.0",
+        "@aws-cdk/aws-kinesisfirehose": "1.79.0",
+        "@aws-cdk/aws-lambda": "1.79.0",
+        "@aws-cdk/aws-logs": "1.79.0",
+        "@aws-cdk/aws-sns": "1.79.0",
+        "@aws-cdk/aws-sns-subscriptions": "1.79.0",
+        "@aws-cdk/aws-sqs": "1.79.0",
+        "@aws-cdk/aws-stepfunctions": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/custom-resources": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-iam": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.79.0.tgz",
+      "integrity": "sha512-lGgmOpdE2f05vQ3oT3pWlybTNb/PQcqkbdiBfvBPRYrg5p3lCGBDFSI3bv7Bjvl7lHhFRnxHnRb4CJRAXcUQqw==",
+      "requires": {
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/region-info": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-kinesis": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kinesis/-/aws-kinesis-1.79.0.tgz",
+      "integrity": "sha512-J7z0tNJM2q6PMJbn4rZa/DBoFhRIJR3fFpGOzow1aexuLl3oHHVpI/Dt6Gxb/ebhfUdX+Dbiul4ACOfHJqdDKw==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-kms": "1.79.0",
+        "@aws-cdk/aws-logs": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-kinesisfirehose": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kinesisfirehose/-/aws-kinesisfirehose-1.79.0.tgz",
+      "integrity": "sha512-XQB8/opTA6FS8V4ozwQPvnaGVkkGtkGWrZ/OQIxMuNeUW+VFk775sD4kzlvhn5+2erDjgXbsK0Mogltd83wahQ==",
+      "requires": {
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-kms": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.79.0.tgz",
+      "integrity": "sha512-vYZUYO9GdOaalkVdJ8/7/f9KzCQh1XtU+MsKgxvXbjhLcjpt1mhPuxs0T+7fNuXbW8YVz1d6Y+BNjv4lEHz2Jw==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/cx-api": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-lambda": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.79.0.tgz",
+      "integrity": "sha512-K6A0nnYRO5MGq+0UdAXk1DRcOELWSPri4f6SNaWu0zhOEBKSAzcVRTJi/cNDs5VniGbGik4/3C5Hd6+8bp5nxA==",
+      "requires": {
+        "@aws-cdk/aws-applicationautoscaling": "1.79.0",
+        "@aws-cdk/aws-cloudwatch": "1.79.0",
+        "@aws-cdk/aws-codeguruprofiler": "1.79.0",
+        "@aws-cdk/aws-ec2": "1.79.0",
+        "@aws-cdk/aws-ecr": "1.79.0",
+        "@aws-cdk/aws-ecr-assets": "1.79.0",
+        "@aws-cdk/aws-efs": "1.79.0",
+        "@aws-cdk/aws-events": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-kms": "1.79.0",
+        "@aws-cdk/aws-logs": "1.79.0",
+        "@aws-cdk/aws-s3": "1.79.0",
+        "@aws-cdk/aws-s3-assets": "1.79.0",
+        "@aws-cdk/aws-sqs": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/cx-api": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-logs": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.79.0.tgz",
+      "integrity": "sha512-J3iYGun//JsqpMl75/b6c+yxA5nY+Dxn0s72TA/BBYzaU4wI2NohwVaqe2X4HIuHniRBVVHBfJ36B3GMKdi4cQ==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-kms": "1.79.0",
+        "@aws-cdk/aws-s3-assets": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-route53": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.79.0.tgz",
+      "integrity": "sha512-IJ32fcC6l1aKhI46wGH7HMUBRMQi8R8Cy9re3kmY4cVdAAfh8UJhIdr8jpaLs2iU0mrJPc4R0tHiCka4aNo2dQ==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.79.0",
+        "@aws-cdk/aws-logs": "1.79.0",
+        "@aws-cdk/cloud-assembly-schema": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/custom-resources": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-route53-targets": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.79.0.tgz",
+      "integrity": "sha512-1hYlCPDnRnxktLoqLgaR/1tGFeFtznhaF0Vish6WFZ4TTDw1wWCArmpyUaJiiaNCDNd7ChQW39J0k+G5WYnA9w==",
+      "requires": {
+        "@aws-cdk/aws-apigateway": "1.79.0",
+        "@aws-cdk/aws-apigatewayv2": "1.79.0",
+        "@aws-cdk/aws-cloudfront": "1.79.0",
+        "@aws-cdk/aws-cognito": "1.79.0",
+        "@aws-cdk/aws-ec2": "1.79.0",
+        "@aws-cdk/aws-elasticloadbalancing": "1.79.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-route53": "1.79.0",
+        "@aws-cdk/aws-s3": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/region-info": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-s3": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.79.0.tgz",
+      "integrity": "sha512-hJM+5jZWoOS4kJ8kXLLOVwjTkWY/BvpkOxuZSLcQV3eq2RFUCwtakx+NTnu+M98eezzme9wAXnKzDFsBcocuHQ==",
+      "requires": {
+        "@aws-cdk/aws-events": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-kms": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-s3-assets": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.79.0.tgz",
+      "integrity": "sha512-P5ktD44LadqqX86IO/5q+cc38BsEeEaUBVCtymagCqYgZvDnkicuSMulcrbMefxUgQ6GLy+F7FuI4o9DHGb0nA==",
+      "requires": {
+        "@aws-cdk/assets": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-kms": "1.79.0",
+        "@aws-cdk/aws-s3": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/cx-api": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-sam": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sam/-/aws-sam-1.79.0.tgz",
+      "integrity": "sha512-+lYwZp95ELoIQbZTE005th0kP2wyLb/cpN/ZuXU4Kd0OSJjaejMmHtoTLie0ojE5MYFSAck8EZ0sNuRv3XUQNg==",
+      "requires": {
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-secretsmanager": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.79.0.tgz",
+      "integrity": "sha512-ELzKvOC8FOBX+fNiqB2ZMun9G11JbioRlGymNs4ZyOAsg6YoqzzhjlCgXOPiA+En9jBp0dZeJaqSdqPwhUCKPg==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-kms": "1.79.0",
+        "@aws-cdk/aws-lambda": "1.79.0",
+        "@aws-cdk/aws-sam": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "@aws-cdk/cx-api": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-servicediscovery": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.79.0.tgz",
+      "integrity": "sha512-3M+CiD1WfH5y/QSoYSkJIBYrQi65iFDq71mT0Ot8KBmERBTxcSgJjgQCqN45XhU522dr2cI9Gu/F03Sl3Reveg==",
+      "requires": {
+        "@aws-cdk/aws-ec2": "1.79.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "1.79.0",
+        "@aws-cdk/aws-route53": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-sns": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.79.0.tgz",
+      "integrity": "sha512-Kmmj0A4anar8JUk8+SZZVJqyqMfsu+9jCMhU3AkKkfpHsnDTj+qz4aPKH+36XIijCQa9A55pjgy5v+k/8WJ81A==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.79.0",
+        "@aws-cdk/aws-events": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-kms": "1.79.0",
+        "@aws-cdk/aws-sqs": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-sns-subscriptions": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.79.0.tgz",
+      "integrity": "sha512-FeLsdUnwMCqyWP0ymQqa3VwLpFReAO8Hp5rihLsHI7dFXNaRflyaeXXbLbffn9AjeqbvqPhwIjTk3fb11STf6A==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-lambda": "1.79.0",
+        "@aws-cdk/aws-sns": "1.79.0",
+        "@aws-cdk/aws-sqs": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-sqs": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.79.0.tgz",
+      "integrity": "sha512-+rWIIHvygEwKmI2hyBXmoYo2sATpwzJw604Bp7stTQKcfp43vls5oq4SKjt87Gld2BO4cavF/ZCaEJO3pXMXyg==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-kms": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-ssm": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.79.0.tgz",
+      "integrity": "sha512-92DAyXS7sZa58LMDz9Or3IlmjgS1etHCBAHM5ombbKOFFwkBdd7A41y2QNXmtv2b61yJYcyetkLkDtmjEwNMaw==",
+      "requires": {
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-kms": "1.79.0",
+        "@aws-cdk/cloud-assembly-schema": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/aws-stepfunctions": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.79.0.tgz",
+      "integrity": "sha512-gk+WYp8s6ILiT6I4Rxf2RH3GD/aotdFkuICi34RW5K1iY1N9obU32+Ljdcx/6vO1xdhTQKxxMERiNl0LWklHLA==",
+      "requires": {
+        "@aws-cdk/aws-cloudwatch": "1.79.0",
+        "@aws-cdk/aws-events": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-logs": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/cloud-assembly-schema": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.79.0.tgz",
+      "integrity": "sha512-n2ARtOXIUq3FdJ1EBuHzsM0DQau6ZwHprPhpk1xc5bv21s7D5X5ECe06eC0K5xC5ZyfC13BDWu1f+xFh+krnYA==",
+      "requires": {
+        "jsonschema": "^1.4.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "jsonschema": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "bundled": true
+        }
+      }
+    },
+    "@aws-cdk/core": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.79.0.tgz",
+      "integrity": "sha512-I+2GbQfbPy6TewnGbviE1W8cUhgBEA1mQLYm5gBj/Rzix1tCyaNvfYsBU3ipg3jIATpHsg1CzUq0zrumUnmnTg==",
+      "requires": {
+        "@aws-cdk/cloud-assembly-schema": "1.79.0",
+        "@aws-cdk/cx-api": "1.79.0",
+        "@aws-cdk/region-info": "1.79.0",
+        "@balena/dockerignore": "^1.0.2",
+        "constructs": "^3.2.0",
+        "fs-extra": "^9.0.1",
+        "ignore": "^5.1.8",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "@balena/dockerignore": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "at-least-node": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "fs-extra": {
+          "version": "9.0.1",
+          "bundled": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "bundled": true
+        },
+        "ignore": {
+          "version": "5.1.8",
+          "bundled": true
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          },
+          "dependencies": {
+            "universalify": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "bundled": true
+        }
+      }
+    },
+    "@aws-cdk/custom-resources": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.79.0.tgz",
+      "integrity": "sha512-+F4dpo/vju7kfNnajw9Fl2XwTmVG7qzYZ6weuKtfr0iFDHrBCZ5auGP45u8gHeNebnCdq51TNG9gskQ3ct5Aiw==",
+      "requires": {
+        "@aws-cdk/aws-cloudformation": "1.79.0",
+        "@aws-cdk/aws-iam": "1.79.0",
+        "@aws-cdk/aws-lambda": "1.79.0",
+        "@aws-cdk/aws-logs": "1.79.0",
+        "@aws-cdk/aws-sns": "1.79.0",
+        "@aws-cdk/core": "1.79.0",
+        "constructs": "^3.2.0"
+      }
+    },
+    "@aws-cdk/cx-api": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.79.0.tgz",
+      "integrity": "sha512-ymQOqHcPzYhrcQ4swMgw5JzAaOm+PehH1cepsxi/Wq2zNOXkyN9o6Hw6l+eDpezFvNIKFy4mMAo6FR9xRCUiow==",
+      "requires": {
+        "@aws-cdk/cloud-assembly-schema": "1.79.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "bundled": true
+        }
+      }
+    },
+    "@aws-cdk/region-info": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.79.0.tgz",
+      "integrity": "sha512-klnXCc1Cd/krE4VOXJ1Blvey8ucPRzuwgGacPsCV2ugMSlaJSbdGqKzTUNxcK2o8g9PaEuJ5lNjfwqqyvp571g=="
+    },
+    "@types/node": {
+      "version": "14.14.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.14.tgz",
+      "integrity": "sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ==",
+      "dev": true
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "constructs": {
+      "version": "3.2.74",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.2.74.tgz",
+      "integrity": "sha512-kINDYW5Xnv/FY+4fbg3G34jvS/kfZ0Th2j/nPPG08peUkXExkY6CB/tarmYmkLIsHGI25x83pQHGDoFl7L8JLA=="
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
+    },
+    "typescript": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "rust_weather_cron",
+  "version": "1.0.0",
+  "description": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/thiskevinwang/rust_weather_cron.git"
+  },
+  "author": "Kevin Wang",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/thiskevinwang/rust_weather_cron/issues"
+  },
+  "homepage": "https://github.com/thiskevinwang/rust_weather_cron#readme",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "cdk": "cdk",
+    "ts-node": "ts-node"
+  },
+  "devDependencies": {
+    "@types/node": "14.14.14",
+    "ts-node": "^9.1.1",
+    "typescript": "4.1.3"
+  },
+  "dependencies": {
+    "@aws-cdk/aws-events": "1.79.0",
+    "@aws-cdk/aws-events-targets": "1.79.0",
+    "@aws-cdk/aws-lambda": "1.79.0",
+    "@aws-cdk/core": "1.79.0",
+    "dotenv": "^8.2.0"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "commonjs",
+    "lib": ["es2018"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "exclude": ["cdk.out"]
+}


### PR DESCRIPTION
Currently, the deploy process is manual, but does leverage infrastructure-as-code

```bash
# build the binary
cargo build --release --target x86_64-unknown-linux-musl

# zip it up, so that aws-cdk TS code can point to it
zip -j rust.zip ./target/x86_64-unknown-linux-musl/release/bootstrap

# deploy with aws-cdk
cdk deploy
```